### PR TITLE
Add option to close dialog after tiling a window

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -22,11 +22,11 @@
             <default>true</default>
         </entry>
 
-        <entry name="maximizeOnBackgroundClick" type="Bool">
-            <default>true</default>
+        <entry name="hideOnFirstTile" type="Bool">
+            <default>false</default>
         </entry>
 
-        <entry name="keepOpen" type="Bool">
+        <entry name="maximizeOnBackgroundClick" type="Bool">
             <default>true</default>
         </entry>
 

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -26,6 +26,9 @@
             <default>true</default>
         </entry>
 
+        <entry name="keepOpen" type="Bool">
+            <default>true</default>
+        </entry>
+
     </group>
 </kcfg>
-

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>382</width>
-    <height>178</height>
+    <height>196</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -104,10 +104,20 @@
    <item>
     <widget class="QCheckBox" name="kcfg_hideOnDesktopClick">
      <property name="text">
-      <string>Hide window when clicked on desktop</string>
+      <string>Hide when clicking on desktop</string>
      </property>
      <property name="checked">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="kcfg_hideOnFirstTile">
+     <property name="text">
+      <string>Hide after tiling a window</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -121,16 +131,6 @@
      </property>
      <property name="text">
       <string>Maximize window when background button is clicked</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="kcfg_keepOpen">
-     <property name="text">
-      <string>Keep open after tiling a window</string>
      </property>
      <property name="checked">
       <bool>true</bool>

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -127,6 +127,16 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QCheckBox" name="kcfg_keepOpen">
+     <property name="text">
+      <string>Keep open after tiling a window</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -55,6 +55,10 @@ PlasmaComponents.Button {
 
                     focusedWindow.setMaximize(false, false);
                     focusedWindow.geometry = Qt.rect(screen.x + newX, screen.y + newY, newWidth, newHeight);
+
+                    if (!keepOpen) {
+                        mainDialog.visible = false;
+                    }
                 }
             }
         }

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -56,7 +56,7 @@ PlasmaComponents.Button {
                     focusedWindow.setMaximize(false, false);
                     focusedWindow.geometry = Qt.rect(screen.x + newX, screen.y + newY, newWidth, newHeight);
 
-                    if (!keepOpen) {
+                    if (hideOnFirstTile) {
                         mainDialog.visible = false;
                     }
                 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -18,6 +18,7 @@ PlasmaCore.Dialog {
     property bool headerVisible: true
     property bool hideOnDesktopClick: true
     property bool maximizeOnBackgroundClick: true
+    property bool keepOpen: true
 
     function loadConfig(){
         columns = KWin.readConfig("columns", 4);
@@ -25,6 +26,7 @@ PlasmaCore.Dialog {
         headerVisible = KWin.readConfig("showHeader", true);
         hideOnDesktopClick = KWin.readConfig("hideOnDesktopClick", true);
         maximizeOnBackgroundClick = KWin.readConfig("maximizeOnBackgroundClick", true);
+        keepOpen = KWin.readConfig("keepOpen", true);
     }
 
     function show() {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -17,16 +17,16 @@ PlasmaCore.Dialog {
     property int position: 1
     property bool headerVisible: true
     property bool hideOnDesktopClick: true
+    property bool hideOnFirstTile: false
     property bool maximizeOnBackgroundClick: true
-    property bool keepOpen: true
 
     function loadConfig(){
         columns = KWin.readConfig("columns", 4);
         position = KWin.readConfig("position", 1);
         headerVisible = KWin.readConfig("showHeader", true);
         hideOnDesktopClick = KWin.readConfig("hideOnDesktopClick", true);
+        hideOnFirstTile = KWin.readConfig("hideOnFirstTile", false);
         maximizeOnBackgroundClick = KWin.readConfig("maximizeOnBackgroundClick", true);
-        keepOpen = KWin.readConfig("keepOpen", true);
     }
 
     function show() {


### PR DESCRIPTION
I found that I more often want to tile just a single window rather than several in a row, so I added an option to close the dialog after a window has been tiled.