### PR TITLE
Multiscreen, and allow pixel level window specifications.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 PACKAGE_NAME=$(kreadconfig5 --file="${PWD}/package/metadata.desktop" --group="Desktop Entry" --key="X-KDE-PluginInfo-Name")
 INSTALL_LOCATION="${HOME}/.local/share/kwin/scripts/"

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -18,6 +18,10 @@
             <default>true</default>
         </entry>
 
+        <entry name="nameAbove" type="Bool">
+            <default>false</default>
+        </entry>
+
         <entry name="showActiveWindowLabel" type="Bool">
             <default>true</default>
         </entry>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -17,6 +17,10 @@
             <default>true</default>
         </entry>
 
+        <entry name="hideTiledWindowTitlebar" type="Bool">
+            <default>false</default>
+        </entry>
+
         <entry name="nameAbove" type="Bool">
             <default>false</default>
         </entry>

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -3,9 +3,8 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://www.kde.org/standards/kcfg/1.0
       http://www.kde.org/standards/kcfg/1.0/kcfg.xsd" >
-    <kcfgfile name=""/>
+    <kcfgfile/>
     <group name="">
-
         <entry name="columns" type="Int">
             <default>5</default>
         </entry>
@@ -53,6 +52,5 @@
         <entry name="tileAvailableWindowsOnBackgroundClick" type="Bool">
             <default>true</default>
         </entry>
-
     </group>
 </kcfg>

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>587</width>
-    <height>330</height>
+    <width>939</width>
+    <height>434</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -225,6 +225,13 @@
          </property>
          <property name="checked">
           <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="kcfg_nameAbove">
+         <property name="text">
+          <string>Name above layout</string>
          </property>
         </widget>
        </item>

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>939</width>
-    <height>434</height>
+    <height>474</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -54,45 +54,10 @@
          <property name="labelAlignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="kcfg_columns">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>12</number>
-           </property>
-           <property name="value">
-            <number>4</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSpinBox" name="kcfg_rows">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="autoFillBackground">
-            <bool>false</bool>
-           </property>
-           <property name="value">
-            <number>2</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_4">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_2">
            <property name="text">
-            <string>Rows</string>
+            <string>Position</string>
            </property>
           </widget>
          </item>
@@ -132,42 +97,6 @@
            </item>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Position</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="QDoubleSpinBox" name="kcfg_tileScale">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimum">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>3.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.300000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_5">
-           <property name="text">
-            <string>Tile Scale</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="0">
           <widget class="QLabel" name="label">
            <property name="sizePolicy">
@@ -178,6 +107,25 @@
            </property>
            <property name="text">
             <string>Columns</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="kcfg_columns">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>12</number>
+           </property>
+           <property name="value">
+            <number>4</number>
            </property>
           </widget>
          </item>

--- a/package/contents/ui/config.ui
+++ b/package/contents/ui/config.ui
@@ -440,13 +440,6 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Disable and re-enable the script in System Settings to apply changes</string>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -90,6 +90,16 @@ PlasmaComponents.Button {
         }
     }
 
+    function spanCheck(normal, raw, screenSize) {
+	if (raw != undefined) {
+	    let val = Math.min(raw / (screenSize / 12.0), 12.0)
+	    val = Math.round(val);
+	    return val;
+	} else {
+	    return normal;
+	}
+    }
+
     SpanGridLayout {
         anchors.fill: parent
         anchors.margins: 10
@@ -118,42 +128,10 @@ PlasmaComponents.Button {
                         return out;
                     } else return "";
                 }
-                Layout.column: {
-                    if (windows[index].hasOwnProperty("rawX")) {
-                        let val = Math.min(windows[index].rawX / (screen.width / 12.0), 12.0);
-                        val = Math.round(val);
-                        return val;
-                    } else {
-                        return windows[index].x;
-                    }
-                }
-                Layout.row: {
-                    if (windows[index].hasOwnProperty("rawY")) {
-                        let val = Math.min(windows[index].rawY / (screen.height / 12.0), 12.0);
-                        val = Math.round(val);
-                        return val;
-                    } else {
-                        return windows[index].y;
-                    }
-                }
-                Layout.rowSpan: {
-                    if (windows[index].hasOwnProperty("rawWidth")) {
-                        let val = Math.min(windows[index].rawWidth / (screen.width / 12.0), 12.0)
-                        val = Math.round(val);
-                        return val;
-                    } else {
-                        return windows[index].width;
-                    }
-                }
-                Layout.columnSpan: {
-                    if (windows[index].hasOwnProperty("rawHeight")) {
-                        let val = Math.min(windows[index].rawHeight / (screen.height / 12.0), 12.0);
-                        val = Math.round(val);
-                        return val;
-                    } else {
-                        return windows[index].height;
-                    }
-                }
+                Layout.column: { root.spanCheck(windows[index].x, windows[index].rawX, screen.width); }
+                Layout.row: { root.spanCheck(windows[index].y, windows[index].rawY, screen.height); }
+                Layout.rowSpan: { root.spanCheck(windows[index].width, windows[index].rawWidth, screen.width); }
+                Layout.columnSpan: { root.spanCheck(windows[index].height, windows[index].rawHeight, screen.height); }
 
                 onClicked: {
                     main.raise();

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -122,7 +122,7 @@ PlasmaComponents.Button {
                     main.requestActivate();
                     focusField.forceActiveFocus();
 
-                    tileWindow(workspace.activeClient, windows[index], root);
+                    tileWindow(main.activeClient, windows[index], root);
 
                     if (!clickedWindows.includes(windows[index])) clickedWindows.push(windows[index]);
 
@@ -141,10 +141,10 @@ PlasmaComponents.Button {
                         let key = [window.shortcutModifier, window.shortcutKey];
                         main.tileShortcuts.set(key, function(workspace, window, tileWindow, root) {
                             return function() {
-                                if (window == undefined || root == undefined || workspace == undefined || workspace.activeClient == undefined) {
+                                if (window == undefined || root == undefined || workspace == undefined || main == undefined || main.activeClient == undefined) {
                                     return;
                                 }
-                                tileWindow(workspace.activeClient, window, root);
+                                tileWindow(main.activeClient, window, root);
                             }
                         }(workspace, window, tileWindow, root));
                     }

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -14,6 +14,7 @@ PlasmaComponents.Button {
     implicitHeight: 90*1.2 * PlasmaCore.Units.devicePixelRatio
 
     property var windows
+    property var screen
     property var clickedWindows: []
 
     function tileWindow(client, window) {
@@ -117,33 +118,37 @@ PlasmaComponents.Button {
                     } else return "";
                 }
                 Layout.column: {
-                    let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
                     if (windows[index].hasOwnProperty("rawX")) {
-                        return = windows[index].rawX / (screen.width / 12.0);
+                        let val = Math.min(windows[index].rawX / (screen.width / 12.0), 12.0);
+                        val = Math.round(val);
+                        return val;
                     } else {
-                        return = windows[index].x;
+                        return windows[index].x;
                     }
                 }
                 Layout.row: {
-                    let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
                     if (windows[index].hasOwnProperty("rawY")) {
-                        return windows[index].rawY / (screen.height / 12.0);
+                        let val = Math.min(windows[index].rawY / (screen.height / 12.0), 12.0);
+                        val = Math.round(val);
+                        return val;
                     } else {
                         return windows[index].y;
                     }
                 }
                 Layout.rowSpan: {
-                    let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
                     if (windows[index].hasOwnProperty("rawWidth")) {
-                        return windows[index].rawWidth / (screen.width / 12.0);
+                        let val = Math.min(windows[index].rawWidth / (screen.width / 12.0), 12.0)
+                        val = Math.round(val);
+                        return val;
                     } else {
                         return windows[index].width;
                     }
                 }
                 Layout.columnSpan: {
-                    let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
                     if (windows[index].hasOwnProperty("rawHeight")) {
-                        return windows[index].rawHeight / (screen.height / 12.0);
+                        let val = Math.min(windows[index].rawHeight / (screen.height / 12.0), 12.0);
+                        val = Math.round(val);
+                        return val;
                     } else {
                         return windows[index].height;
                     }

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -20,7 +20,7 @@ PlasmaComponents.Button {
 
     function tileWindow(client, window, root) {
         var screen = root.screen;
-        if (screen == undefined) { console.log("screen"); return; }
+        if (screen == undefined) { console.log("screen not defined"); return; }
         if (!client.normalWindow) return;
         if (root.main.rememberWindowGeometries && !root.main.oldWindowGemoetries.has(client)) root.main.oldWindowGemoetries.set(client, [client.geometry.width, client.geometry.height]);
 

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -24,11 +24,31 @@ PlasmaComponents.Button {
 
         let xMult = screen.width / 12.0;
         let yMult = screen.height / 12.0;
+        let x = 0.0;
+        let y = 0.0;
+        let width = 0.0;
+        let height = 0.0;
 
-        let newX = Math.round(window.x * xMult) + tileGap;
-        let newY = Math.round(window.y * yMult) + tileGap;
-        let newWidth = Math.round(window.width * xMult) - 2*tileGap;
-        let newHeight = Math.round(window.height * yMult) - 2*tileGap;
+        if (window.hasOwnProperty("rawX")) {
+            x = window.rawX;
+        } else {
+            x = Math.round(window.x * xMult) + tileGap;
+        }
+        if (window.hasOwnProperty("rawY")) {
+            y = window.rawY;
+        } else {
+            y = Math.round(window.y * yMult) + tileGap;
+        }
+        if (window.hasOwnProperty("rawWidth")) {
+            width = window.rawWidth;
+        } else {
+            width = Math.round(window.width * xMult) - 2*tileGap;
+        }
+        if (window.hasOwnProperty("rawWidth")) {
+            height = window.rawHeight;
+        } else {
+            height = Math.round(window.height * yMult) - 2*tileGap;
+        }
 
         client.setMaximize(false, false);
         client.geometry = Qt.rect(screen.x + newX, screen.y + newY, newWidth, newHeight);
@@ -96,10 +116,38 @@ PlasmaComponents.Button {
                         return out;
                     } else return "";
                 }
-                Layout.row: windows[index].y
-                Layout.rowSpan: windows[index].width
-                Layout.column: windows[index].x
-                Layout.columnSpan: windows[index].height
+                Layout.column: {
+                    let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
+                    if (windows[index].hasOwnProperty("rawX")) {
+                        return = windows[index].rawX / (screen.width / 12.0);
+                    } else {
+                        return = windows[index].x;
+                    }
+                }
+                Layout.row: {
+                    let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
+                    if (windows[index].hasOwnProperty("rawY")) {
+                        return windows[index].rawY / (screen.height / 12.0);
+                    } else {
+                        return windows[index].y;
+                    }
+                }
+                Layout.rowSpan: {
+                    let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
+                    if (windows[index].hasOwnProperty("rawWidth")) {
+                        return windows[index].rawWidth / (screen.width / 12.0);
+                    } else {
+                        return windows[index].width;
+                    }
+                }
+                Layout.columnSpan: {
+                    let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
+                    if (windows[index].hasOwnProperty("rawHeight")) {
+                        return windows[index].rawHeight / (screen.height / 12.0);
+                    } else {
+                        return windows[index].height;
+                    }
+                }
 
                 onClicked: {
                     mainDialog.raise();

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -31,26 +31,10 @@ PlasmaComponents.Button {
         let width = 0.0;
         let height = 0.0;
 
-        if (window.hasOwnProperty("rawX")) {
-            x = window.rawX;
-        } else {
-            x = Math.round(window.x * xMult) + tileGap;
-        }
-        if (window.hasOwnProperty("rawY")) {
-            y = window.rawY;
-        } else {
-            y = Math.round(window.y * yMult) + tileGap;
-        }
-        if (window.hasOwnProperty("rawWidth")) {
-            width = window.rawWidth;
-        } else {
-            width = Math.round(window.width * xMult) - 2*tileGap;
-        }
-        if (window.hasOwnProperty("rawWidth")) {
-            height = window.rawHeight;
-        } else {
-            height = Math.round(window.height * yMult) - 2*tileGap;
-        }
+        x = window.rawX ?? Math.round(window.x * xMult) + tileGap;
+        y = window.rawY ?? Math.round(window.y * yMult) + tileGap;
+        width = window.rawWidth ?? Math.round(window.width * xMult) - 2*tileGap;
+        height = window.rawHeight ?? Math.round(window.height * yMult) - 2*tileGap;
 
         client.setMaximize(false, false);
         client.geometry = Qt.rect(screen.x + x, screen.y + y, width, height);

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -51,9 +51,7 @@ PlasmaComponents.Button {
     }
 
     onClicked: {
-        main.raise();
-        main.requestActivate();
-        focusField.forceActiveFocus();
+        main.doRaise(true);
 
         if (tileAvailableWindowsOnBackgroundClick) {
             let clientList = [];
@@ -118,7 +116,7 @@ PlasmaComponents.Button {
                 Layout.columnSpan: { root.spanCheck(windows[index].height, windows[index].rawHeight, screen.height); }
 
                 onClicked: {
-                    main.raise();
+                    main.doRaise(true);
                     main.requestActivate();
                     focusField.forceActiveFocus();
 

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -13,14 +13,14 @@ PlasmaComponents.Button {
     implicitWidth: 160*1.2 * PlasmaCore.Units.devicePixelRatio
     implicitHeight: 90*1.2 * PlasmaCore.Units.devicePixelRatio
 
+    property var main
     property var windows
     property var screen
     property var clickedWindows: []
 
     function tileWindow(client, window) {
         if (!client.normalWindow) return;
-        if (rememberWindowGeometries && !oldWindowGemoetries.has(client)) oldWindowGemoetries.set(client, [client.geometry.width, client.geometry.height]);
-
+        if (root.main.rememberWindowGeometries && !root.main.oldWindowGemoetries.has(client)) root.main.oldWindowGemoetries.set(client, [client.geometry.width, client.geometry.height]);
         let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, client.desktop);
 
         let xMult = screen.width / 12.0;
@@ -66,8 +66,8 @@ PlasmaComponents.Button {
     }
 
     onClicked: {
-        mainDialog.raise();
-        mainDialog.requestActivate();
+        main.raise();
+        main.requestActivate();
         focusField.forceActiveFocus();
 
         if (tileAvailableWindowsOnBackgroundClick) {
@@ -85,7 +85,7 @@ PlasmaComponents.Button {
                 workspace.activeClient = client;
             }
 
-            if (hideOnFirstTile || hideOnLayoutTiled) mainDialog.visible = false;
+            if (hideOnFirstTile || hideOnLayoutTiled) main.hide();
         }
     }
 
@@ -155,18 +155,18 @@ PlasmaComponents.Button {
                 }
 
                 onClicked: {
-                    mainDialog.raise();
-                    mainDialog.requestActivate();
+                    main.raise();
+                    main.requestActivate();
                     focusField.forceActiveFocus();
 
                     tileWindow(activeClient, windows[index]);
 
                     if (!clickedWindows.includes(windows[index])) clickedWindows.push(windows[index]);
 
-                    if (hideOnFirstTile) mainDialog.visible = false;
+                    if (hideOnFirstTile) main.hide();
                     if (hideOnLayoutTiled && clickedWindows.length === windows.length) {
                         clickedWindows = [];
-                        mainDialog.visible = false;
+                        main.hide();
                     }
                 }
 

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -53,8 +53,8 @@ PlasmaComponents.Button {
         }
 
         client.setMaximize(false, false);
-        client.geometry = Qt.rect(screen.x + newX, screen.y + newY, newWidth, newHeight);
-        if (hideTiledWindowTitlebar) client.noBorder = true;
+        client.geometry = Qt.rect(screen.x + x, screen.y + y, width, height);
+        if (root.main.hideTiledWindowTitlebar) client.noBorder = true;
     }
 
     function childHasFocus() {

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -16,23 +16,23 @@ PlasmaComponents.Button {
     property var windows
     property var clickedWindows: []
 
-    function tileWindow(window, x, y, width, height) {
-        if (!window.normalWindow) return;
-        if (rememberWindowGeometries && !oldWindowGemoetries.has(window)) oldWindowGemoetries.set(window, [window.geometry.width, window.geometry.height]);
+    function tileWindow(client, window) {
+        if (!client.normalWindow) return;
+        if (rememberWindowGeometries && !oldWindowGemoetries.has(client)) oldWindowGemoetries.set(client, [client.geometry.width, client.geometry.height]);
 
-        let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, window.desktop);
+        let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, client.desktop);
 
         let xMult = screen.width / 12.0;
         let yMult = screen.height / 12.0;
 
-        let newX = Math.round(x * xMult) + tileGap;
-        let newY = Math.round(y * yMult) + tileGap;
-        let newWidth = Math.round(width * xMult) - 2*tileGap;
-        let newHeight = Math.round(height * yMult) - 2*tileGap;
+        let newX = Math.round(window.x * xMult) + tileGap;
+        let newY = Math.round(window.y * yMult) + tileGap;
+        let newWidth = Math.round(window.width * xMult) - 2*tileGap;
+        let newHeight = Math.round(window.height * yMult) - 2*tileGap;
 
-        window.setMaximize(false, false);
-        window.geometry = Qt.rect(screen.x + newX, screen.y + newY, newWidth, newHeight);
-        if (hideTiledWindowTitlebar) window.noBorder = true;
+        client.setMaximize(false, false);
+        client.geometry = Qt.rect(screen.x + newX, screen.y + newY, newWidth, newHeight);
+        if (hideTiledWindowTitlebar) client.noBorder = true;
     }
 
     function childHasFocus() {
@@ -60,7 +60,7 @@ PlasmaComponents.Button {
             for (let i = 0; i < clientList.length; i++) {
                 if (i >= windows.length || i >= clientList.length) return;
                 let client = clientList[i];
-                tileWindow(client, windows[i].x, windows[i].y, windows[i].width, windows[i].height);
+                tileWindow(client, windows[i]);
                 workspace.activeClient = client;
             }
 
@@ -106,7 +106,7 @@ PlasmaComponents.Button {
                     mainDialog.requestActivate();
                     focusField.forceActiveFocus();
 
-                    tileWindow(activeClient, windows[index].x, windows[index].y, windows[index].width, windows[index].height);
+                    tileWindow(activeClient, windows[index]);
 
                     if (!clickedWindows.includes(windows[index])) clickedWindows.push(windows[index]);
 
@@ -124,7 +124,7 @@ PlasmaComponents.Button {
                     if (window.shortcutKey) {
                         let key = [window.shortcutModifier, window.shortcutKey];
                         tileShortcuts.set(key, () => {
-                            tileWindow(activeClient, window.x, window.y, window.width, window.height);
+                            tileWindow(activeClient, window);
                         });
                     }
                 }

--- a/package/contents/ui/lib/WindowLayout.qml
+++ b/package/contents/ui/lib/WindowLayout.qml
@@ -18,10 +18,11 @@ PlasmaComponents.Button {
     property var screen
     property var clickedWindows: []
 
-    function tileWindow(client, window) {
+    function tileWindow(client, window, root) {
+        var screen = root.screen;
+        if (screen == undefined) { console.log("screen"); return; }
         if (!client.normalWindow) return;
         if (root.main.rememberWindowGeometries && !root.main.oldWindowGemoetries.has(client)) root.main.oldWindowGemoetries.set(client, [client.geometry.width, client.geometry.height]);
-        let screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, client.desktop);
 
         let xMult = screen.width / 12.0;
         let yMult = screen.height / 12.0;
@@ -81,7 +82,7 @@ PlasmaComponents.Button {
             for (let i = 0; i < clientList.length; i++) {
                 if (i >= windows.length || i >= clientList.length) return;
                 let client = clientList[i];
-                tileWindow(client, windows[i]);
+                tileWindow(client, windows[i], root);
                 workspace.activeClient = client;
             }
 
@@ -159,7 +160,7 @@ PlasmaComponents.Button {
                     main.requestActivate();
                     focusField.forceActiveFocus();
 
-                    tileWindow(activeClient, windows[index]);
+                    tileWindow(workspace.activeClient, windows[index], root);
 
                     if (!clickedWindows.includes(windows[index])) clickedWindows.push(windows[index]);
 
@@ -176,9 +177,14 @@ PlasmaComponents.Button {
                     // Register shortcuts
                     if (window.shortcutKey) {
                         let key = [window.shortcutModifier, window.shortcutKey];
-                        tileShortcuts.set(key, () => {
-                            tileWindow(activeClient, window);
-                        });
+                        main.tileShortcuts.set(key, function(workspace, window, tileWindow, root) {
+                            return function() {
+                                if (window == undefined || root == undefined || workspace == undefined || workspace.activeClient == undefined) {
+                                    return;
+                                }
+                                tileWindow(workspace.activeClient, window, root);
+                            }
+                        }(workspace, window, tileWindow, root));
                     }
                 }
             }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -196,6 +196,7 @@ PlasmaCore.Dialog {
 
                     windows: layoutFile.item.windows
                     screen: mainDialog.screen
+                    main: mainDialog
                 }
             }
         }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -210,7 +210,9 @@ PlasmaCore.Dialog {
                 tileShortcuts.forEach((tileFunction, key) => {
                     let shortcutModifier = key[0] ? key[0] : Qt.NoModifier;
                     let shortcutKey = key[1];
-                    if (event.key === shortcutKey && event.modifiers === shortcutModifier) tileFunction();
+                    if (event.key === shortcutKey && event.modifiers === shortcutModifier) {
+                        tileFunction();
+                    }
                 });
             }
         }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import QtQuick.Layouts 1.0
+import QtQuick.Layouts 1.3
 import Qt.labs.folderlistmodel 2.15
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 3.0 as PlasmaComponents

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -110,7 +110,7 @@ PlasmaCore.Dialog {
                 disconnectSource(sourceName);
             }
             function exec() {
-                mainDialog.visible = false;
+                mainDialog.hide();
                 connectSource(`bash ${Qt.resolvedUrl("./").replace(/^(file:\/{2})/,"")}restartKWin.sh`);
             }
         }
@@ -220,7 +220,7 @@ PlasmaCore.Dialog {
             function onClientActivated(client) {
                 if (!client) return;
                 if (hideOnDesktopClick && workspace.activeClient.desktopWindow)
-                    mainDialog.visible = false;
+                    mainDialog.hide();
 
                 activeClient = workspace.activeClient;
             }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -96,6 +96,7 @@ PlasmaCore.Dialog {
     function hide() {
         focusTimer.running = false;
         mainDialog.visible = false;
+        mainDialog.tileShortcuts.clear();
     }
 
     ColumnLayout {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -224,8 +224,10 @@ PlasmaCore.Dialog {
                                 } else {
                                     return workspace.clientArea(KWin.MaximizeArea, 0, workspace.currentDesktop);
                                 }
-                            } else {
+                            } else if (mainDialog.screen != undefined) {
                                 return mainDialog.screen;
+                            } else {
+                                return workspace.clientArea(KWin.MaximizeArea, 0, workspace.currentDesktop);
                             }
                         }
                         main: mainDialog

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -56,6 +56,14 @@ PlasmaCore.Dialog {
         mainDialog.screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
         var screen = mainDialog.screen
 
+        // We want layoutsRepeater to regenerate all of it's children.
+        // To make that happen, we save the model it is using, set the model to
+        // undefined, and then restore the model.
+        // It's a hack, but it works.
+        var model = layoutsRepeater.model;
+        layoutsRepeater.model = undefined;
+        layoutsRepeater.model = model;
+
         focusTimer.running = true;
 
         activeClient = workspace.activeClient;

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -196,15 +196,30 @@ PlasmaCore.Dialog {
                     return false;
                 }
 
-                WindowLayout {
-                    Loader {
-                        id: layoutFile
-                        source: fileUrl
+                ColumnLayout {
+                    id: column
+                    function childHasFocus() {
+                        return layout.childHasFocus();
                     }
 
-                    windows: layoutFile.item.windows
-                    screen: mainDialog.screen
-                    main: mainDialog
+                    Text {
+                        id: label
+                        text: layoutFile.item.name
+                        color: "white"
+                        font.pointSize: 15
+                    }
+
+                    WindowLayout {
+                        Loader {
+                            id: layoutFile
+                            source: fileUrl
+                        }
+
+                        id: layout
+                        windows: layoutFile.item.windows
+                        screen: mainDialog.screen
+                        main: mainDialog
+                    }
                 }
             }
         }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -73,9 +73,7 @@ PlasmaCore.Dialog {
 
         mainDialog.visible = true;
 
-        mainDialog.raise();
-        mainDialog.requestActivate();
-        focusField.forceActiveFocus();
+        mainDialog.doRaise(true);
 
         switch (position) {
             case 0:
@@ -112,6 +110,14 @@ PlasmaCore.Dialog {
         focusTimer.running = false;
         mainDialog.visible = false;
         mainDialog.tileShortcuts.clear();
+    }
+
+    function doRaise(forceActiveFocus) {
+        mainDialog.raise();
+        mainDialog.requestActivate();
+        if (forceActiveFocus) {
+            focusField.forceActiveFocus();
+        }
     }
 
     ColumnLayout {
@@ -258,8 +264,7 @@ PlasmaCore.Dialog {
             visible: false
 
             onActiveFocusChanged: {
-                mainDialog.raise();
-                mainDialog.requestActivate();
+                mainDialog.doRaise(false);
             }
 
             Keys.onEscapePressed: mainDialog.hide()
@@ -317,9 +322,7 @@ PlasmaCore.Dialog {
 
             onTriggered: {
                 if (!focusField.focused && !closeButton.hovered && !layoutsRepeater.childHasFocus()) {
-                    mainDialog.raise();
-                    mainDialog.requestActivate();
-                    focusField.forceActiveFocus();
+                    mainDialog.doRaise(true);
                 }
             }
         }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -310,13 +310,6 @@ PlasmaCore.Dialog {
         }
 
         Connections {
-            target: options
-            function onConfigChanged() {
-                mainDialog.loadConfig();
-            }
-        }
-
-        Connections {
             target: workspace.activeClient
             function onMoveResizedChanged() {
                 if (rememberWindowGeometries) {
@@ -348,6 +341,7 @@ PlasmaCore.Dialog {
     }
 
     Component.onCompleted: {
+        options.configChanged.connect(mainDialog.loadConfig);
         KWin.registerWindow(mainDialog);
         KWin.registerShortcut(
             "Exquisite",
@@ -358,7 +352,7 @@ PlasmaCore.Dialog {
                     mainDialog.hide();
                 } else {
                     mainDialog.hide();
-                    mainDialog.loadConfig();
+                    options.configChanged();
                     mainDialog.show();
                 }
             }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -276,6 +276,7 @@ PlasmaCore.Dialog {
                 if (mainDialog.visible) {
                     mainDialog.hide();
                 } else {
+                    mainDialog.hide();
                     mainDialog.loadConfig();
                     mainDialog.show();
                 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -217,7 +217,17 @@ PlasmaCore.Dialog {
 
                         id: layout
                         windows: layoutFile.item.windows
-                        screen: mainDialog.screen
+                        screen: {
+                            if (layoutFile.item.screen != undefined) {
+                                if (layoutFile.item.screen < workspace.numScreens) {
+                                    return workspace.clientArea(KWin.MaximizeArea, layoutFile.item.screen, workspace.currentDesktop);
+                                } else {
+                                    return workspace.clientArea(KWin.MaximizeArea, 0, workspace.currentDesktop);
+                                }
+                            } else {
+                                return mainDialog.screen;
+                            }
+                        }
                         main: mainDialog
                     }
                 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -4,6 +4,7 @@ import Qt.labs.folderlistmodel 2.15
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 3.0 as PlasmaComponents
 import org.kde.kwin 2.0
+import org.kde.kirigami 2.20 as Kirigami
 
 import "lib"
 
@@ -19,6 +20,7 @@ PlasmaCore.Dialog {
     property int columns: 5
     property int position: 1
     property double tileScale: 1.3
+    property bool nameAbove: false
     property bool headerVisible: true
     property bool activeWindowLabelVisible: true
     property bool restartButtonVisible: true
@@ -38,6 +40,7 @@ PlasmaCore.Dialog {
         columns = KWin.readConfig("columns", 5);
         position = KWin.readConfig("position", 1);
         tileScale = KWin.readConfig("tileScale", 1.3);
+        nameAbove = KWin.readConfig("nameAbove", false);
         headerVisible = KWin.readConfig("showHeader", true);
         activeWindowLabelVisible = KWin.readConfig("showActiveWindowLabel", true);
         restartButtonVisible = KWin.readConfig("showRestartButton", true);
@@ -202,11 +205,14 @@ PlasmaCore.Dialog {
                         return layout.childHasFocus();
                     }
 
-                    Text {
-                        id: label
+                    PlasmaComponents.Label {
+                        id: labelTop
+                        visible: nameAbove
                         text: layoutFile.item.name
-                        color: "white"
-                        font.pointSize: 15
+                        color: Kirigami.Theme.disabledTextColor
+                        width: layout.width
+                        elide: Text.ElideRight
+                        Layout.alignment: Qt.AlignHCenter
                     }
 
                     WindowLayout {
@@ -231,6 +237,16 @@ PlasmaCore.Dialog {
                             }
                         }
                         main: mainDialog
+                    }
+
+                    PlasmaComponents.Label {
+                        id: labelBottom
+                        visible: !nameAbove
+                        text: layoutFile.item.name
+                        color: Kirigami.Theme.disabledTextColor
+                        width: layout.width
+                        elide: Text.ElideRight
+                        Layout.alignment: Qt.AlignHCenter
                     }
                 }
             }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -254,7 +254,7 @@ PlasmaCore.Dialog {
             id: focusTimer
             interval: 100
             repeat: true
-            running: true
+            running: false
 
             onTriggered: {
                 if (!focusField.focused && !closeButton.hovered && !layoutsRepeater.childHasFocus()) {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -14,6 +14,7 @@ PlasmaCore.Dialog {
     visible: false
 
     property var activeClient
+    property var screen
 
     property int columns: 5
     property int position: 1
@@ -51,6 +52,10 @@ PlasmaCore.Dialog {
     }
 
     function show() {
+        // Get the current screen.
+        mainDialog.screen = workspace.clientArea(KWin.MaximizeArea, workspace.activeScreen, workspace.currentDesktop);
+        var screen = mainDialog.screen
+
         focusTimer.running = true;
 
         activeClient = workspace.activeClient;
@@ -61,7 +66,6 @@ PlasmaCore.Dialog {
         mainDialog.requestActivate();
         focusField.forceActiveFocus();
 
-        var screen = workspace.clientArea(KWin.FullScreenArea, workspace.activeScreen, workspace.currentDesktop);
         switch (position) {
             case 0:
                 mainDialog.x = screen.x + screen.width/2 - mainDialog.width/2;
@@ -191,6 +195,7 @@ PlasmaCore.Dialog {
                     }
 
                     windows: layoutFile.item.windows
+                    screen: mainDialog.screen
                 }
             }
         }


### PR DESCRIPTION
There are a few too many things in this for my preferences, but the changes are tied together in important ways.

Significant changes:

1. You can now specify the X, Y, width, and height as 'raw' values, which are in pixels.
2. The layout QML files are now reloaded every time you bring up the tiling dialog. (This was more of an accident than anything else.  We need to recalculate things when bringing up the dialog on a different screen.)
3. You can now specify a screen number for a given layout. (This is _not_ per window, because I can't come up with a sane way to render that in the dialog.  So people are going to be stuck with a layout put monitor.)
4. And the layout names are now used for something!  We get a text label above each layout in the dialog.
5. There are also some bug fixes around showing vs hiding the dialog, and how that interacts with the running focus task.  This also fixed some bugs around shortcuts with number 2.

